### PR TITLE
support for m2e 1.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .classpath
 .project
 **/.settings/
+
+# update-site
+**/updateSite/**/*

--- a/org.levigo.m2e.assertj.feature/feature.xml
+++ b/org.levigo.m2e.assertj.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.levigo.m2e.assertj.feature"
       label="%featureName"
-      version="0.6.0.qualifier"
+      version="0.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.levigo.m2e.assertj">
 

--- a/org.levigo.m2e.assertj.feature/pom.xml
+++ b/org.levigo.m2e.assertj.feature/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.levigo.m2e</groupId>
     <artifactId>org.levigo.m2e.assertj.parent</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.6.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>org.levigo.m2e.assertj.feature</artifactId>

--- a/org.levigo.m2e.assertj.p2updatesite/category.xml
+++ b/org.levigo.m2e.assertj.p2updatesite/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.levigo.m2e.assertj.feature_0.6.0.jar" id="org.levigo.m2e.assertj.feature" version="0.6.0.qualifier">
+   <feature url="features/org.levigo.m2e.assertj.feature_0.6.1.jar" id="org.levigo.m2e.assertj.feature" version="0.6.1.qualifier">
       <category name="m2e-assertj"/>
    </feature>
    <category-def name="m2e-assertj" label="AssertJ-Connnector for M2E"/>

--- a/org.levigo.m2e.assertj.p2updatesite/pom.xml
+++ b/org.levigo.m2e.assertj.p2updatesite/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.levigo.m2e</groupId>
 		<artifactId>org.levigo.m2e.assertj.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.6.1-SNAPSHOT</version>
 	</parent>
 
 	<properties>
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho.extras</groupId>
 				<artifactId>tycho-eclipserun-plugin</artifactId>
-				<version>${tycho-version}</version>
+				<version>${tychoVersion}</version>
 				<configuration>
 					<!-- IMPORTANT: DO NOT split the arg line -->
 					<appArgLine>-application org.eclipse.ant.core.antRunner -buildfile packaging-p2composite.ant p2.composite.add -Dsite.label="M2E AssertJ update site" -Dproject.build.directory=${project.build.directory} -DunqualifiedVersion=${unqualifiedVersion} -DbuildQualifier=${buildQualifier}</appArgLine>

--- a/org.levigo.m2e.assertj.tests/META-INF/MANIFEST.MF
+++ b/org.levigo.m2e.assertj.tests/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: m2e plugin for AssertJ tests
 Bundle-SymbolicName: org.levigo.m2e.assertj.tests
-Bundle-Version: 0.5.0.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-Version: 0.6.1.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.eclipse.m2e.tests.common;bundle-version="[1.0.0,2.0.0)",
  org.junit;bundle-version="3.8.2",
  org.eclipse.m2e.core;bundle-version="[1.0.0,2.0.0)",
  org.eclipse.core.resources;bundle-version="3.4.2",
- org.eclipse.core.runtime;bundle-version="[3.6.0,4.0)",
- org.eclipse.jdt.core;bundle-version="[3.4.4,4.0)",
- org.levigo.m2e.assertj;bundle-version="0.5.0"
+ org.eclipse.core.runtime;bundle-version="[3.6.0,4.12)",
+ org.eclipse.jdt.core;bundle-version="[3.4.4,4.12)",
+ org.levigo.m2e.assertj;bundle-version="0.6.1"
 Bundle-Vendor: levigo solutions gmbh

--- a/org.levigo.m2e.assertj.tests/pom.xml
+++ b/org.levigo.m2e.assertj.tests/pom.xml
@@ -12,7 +12,7 @@
   <parent>
     <groupId>org.levigo.m2e</groupId>
     <artifactId>org.levigo.m2e.assertj.parent</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <version>0.6.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>org.levigo.m2e.assertj.tests</artifactId>

--- a/org.levigo.m2e.assertj/META-INF/MANIFEST.MF
+++ b/org.levigo.m2e.assertj/META-INF/MANIFEST.MF
@@ -2,13 +2,13 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: m2e connector for assertj
 Bundle-SymbolicName: org.levigo.m2e.assertj;singleton:=true
-Bundle-Version: 0.6.0.qualifier
+Bundle-Version: 0.6.1.qualifier
 Bundle-Vendor: levigo solutions gmbh
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Require-Bundle: org.eclipse.core.resources;bundle-version="[3.6.0,4.0)",
- org.eclipse.core.runtime;bundle-version="[3.6.0,4.0)",
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Require-Bundle: org.eclipse.core.resources;bundle-version="[3.6.0,4.12)",
+ org.eclipse.core.runtime;bundle-version="[3.6.0,4.12)",
  org.eclipse.m2e.jdt;bundle-version="[1.0.0,2.0)",
  org.eclipse.m2e.core;bundle-version="[1.0.0,2.0)",
  org.eclipse.m2e.maven.runtime;bundle-version="[1.0.0,2.0)",
  org.slf4j.api;bundle-version="[1.5.0,2.0)",
- org.eclipse.jdt.core;bundle-version="[3.0,4.0)"
+ org.eclipse.jdt.core;bundle-version="[3.10,4.12)"

--- a/org.levigo.m2e.assertj/pom.xml
+++ b/org.levigo.m2e.assertj/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>org.levigo.m2e</groupId>
 		<artifactId>org.levigo.m2e.assertj.parent</artifactId>
-		<version>0.6.0-SNAPSHOT</version>
+		<version>0.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.levigo.m2e.assertj</artifactId>

--- a/org.levigo.m2e.assertj/src/org/levigo/m2e/assertj/internal/AssertJProjectConfigurator.java
+++ b/org.levigo.m2e.assertj/src/org/levigo/m2e/assertj/internal/AssertJProjectConfigurator.java
@@ -50,6 +50,9 @@ public class AssertJProjectConfigurator extends AbstractSourcesGenerationProject
         if(sourcePath != null) {
           IClasspathEntryDescriptor entry = classpath.addSourceEntry(sourcePath, facade.getTestOutputLocation(), true);
           entry.setClasspathAttribute(IClasspathAttribute.IGNORE_OPTIONAL_PROBLEMS, "true"); //$NON-NLS-1$
+          entry.setClasspathAttribute(IClasspathAttribute.OPTIONAL, "true"); //$NON-NLS-1$
+          entry.setClasspathAttribute(IClasspathAttribute.TEST, "true"); //$NON-NLS-1$
+          entry.setClasspathAttribute("maven.pomderived", "true"); //$NON-NLS-1$
         }
       }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.levigo.m2e</groupId>
   <artifactId>org.levigo.m2e.assertj.parent</artifactId>
-  <version>0.6.0-SNAPSHOT</version>
+  <version>0.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>M2E AssertJ Maven connector</name>
 
@@ -19,16 +19,51 @@
     <p2MetadataName>M2E AssertJ Maven connector</p2MetadataName>
 
     <tycho-version>${tychoVersion}</tycho-version>
-    <tycho-extras-version>1.0.0</tycho-extras-version>
+    <tychoVersion>1.2.0</tychoVersion>
+    <tycho-extras-version>1.2.0</tycho-extras-version>
     <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <platform-version>[3.9,5.0)</platform-version>
+    <m2e-core.url>http://download.eclipse.org/technology/m2e/releases/1.10/</m2e-core.url>
+    <tycho.test.jvmArgs>-Xmx512m</tycho.test.jvmArgs>
   </properties>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-surefire-plugin</artifactId>
+          <version>${tychoVersion}</version>
+          <configuration>
+            <failIfNoTests>false</failIfNoTests>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
   <modules>
     <module>org.levigo.m2e.assertj</module>
     <module>org.levigo.m2e.assertj.feature</module>
     <module>org.levigo.m2e.assertj.tests</module>
     <module>org.levigo.m2e.assertj.p2updatesite</module>
   </modules>
+
+  <repositories>
+    <!-- 
+      The org.eclipse.m2e.tests.common bundle is deployed to the m2e releases repository but is not 
+      part of the simultaneous release. The connectors use this bundle for testing so we need to
+      be able to pick it up.
+    -->
+    <repository>
+      <id>m2e-core</id>
+      <url>${m2e-core.url}</url>
+      <layout>p2</layout>
+    </repository>
+    <repository>
+      <id>luna</id>
+      <url>http://download.eclipse.org/releases/photon</url>
+      <layout>p2</layout>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
I have extended the project-configurator for adding support for new options in m2e1.11 (separation of sources and test-soures). That is needed for compatibility with newer versions of m2e, because the project-configuration becomes invalid otherwise on every call to maven->update project.